### PR TITLE
Some simple changes to display of status page and additional field in reservations struct

### DIFF
--- a/api.go
+++ b/api.go
@@ -74,7 +74,9 @@ func (ge *Endpoint) getReservations() ([]reservation, error) {
 	for rows.Next() {
 		res := reservation{}
 		rows.Scan(&res.JobID, &res.App, &res.Component, &res.Owner, &res.Notify, &res.Frequency, &res.TimeUnits, &res.LastCheckin, &res.NumCheckins)
-		res.LastCheckinStr = time.Unix(res.LastCheckin, 0).Format(time.RFC1123)
+		lastCheckin := time.Unix(res.LastCheckin, 0)
+		res.TimeSinceLastCheckin = RelTime(lastCheckin, time.Now(), "ago", "")
+		res.LastCheckinStr = lastCheckin.Format(time.RFC1123)
 		if FailsSLA(res) {
 			res.FailingSLA = true
 		} else {
@@ -283,6 +285,6 @@ func InitAPI(ge *Endpoint, port int, htmlPath string) {
 		return
 	})
 
-	server := http.ListenAndServe(":8080", nil)
+	server := http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
 	log.Panic(server)
 }

--- a/cmd/gotelweb/gotel.go
+++ b/cmd/gotelweb/gotel.go
@@ -40,5 +40,5 @@ func main() {
 			gotel.Monitor(ge.Db)
 		}
 	}()
-	gotel.InitAPI(ge, 8090, *htmlPath)
+	gotel.InitAPI(ge, 8080, *htmlPath)
 }

--- a/cmd/gotelweb/gotel.go
+++ b/cmd/gotelweb/gotel.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"flag"
-	"github.com/CrowdStrike/gotel"
+
 	"github.com/ParsePlatform/go.flagenv"
+	"github.com/schleppy/gotel"
+
+	"log"
 
 	_ "github.com/go-sql-driver/mysql"
-	"log"
 
 	"time"
 )
@@ -38,5 +40,5 @@ func main() {
 			gotel.Monitor(ge.Db)
 		}
 	}()
-	gotel.InitAPI(ge, 8080, *htmlPath)
+	gotel.InitAPI(ge, 8090, *htmlPath)
 }

--- a/public/view.html
+++ b/public/view.html
@@ -1,54 +1,53 @@
+<!DOCTYPE html>
 <html>
-<head>
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
-<style>
-table, td, th {
-    border: 1px solid black;
-}
-th {
-    background-color: black;
-    color: white;
-    padding:2px;
-}
-td {
-	padding:5px;
-	font-size: 14px;
-}
-</style>
-<!-- Latest compiled and minified CSS -->
-</head>
-<body>
- <h1>GoTel Reservations</h1>
- <table width="90%" style="margin: 20px 20px;" cellpadding="10">
- 	<tr>
- 		<th>JobID</th>
- 		<th>App</th>
- 		<th>Component</th>
- 		<th>Owner</th>
- 		<th>Frequency</th>
- 		<th>TimeUnits</th>
- 		<th>LastCheckin</th>
- 		<th>Num Checkins</th>
- 		<th>Status</th>
- 	</tr>
- {{range .}}
-    <tr>
-    <td>{{.JobID}}</td>
-    <td>{{.App}}</td>
-    <td>{{.Component}}</td>
-    <td>{{.Owner}}</td>
-    <td>{{.Frequency}}</td>
-    <td>{{.TimeUnits}}</td>
-    <td>{{.LastCheckinStr}}</td>
-    <td>{{.NumCheckins}}</td>
-    {{ if .FailingSLA }}
-    	<td><span style="color:red">FAILING</span></td>
-    {{ else }}
-		<td><span style="color:green">OK</span></td>
-    {{ end }}
-    </tr>
- {{end}}
-  </ul>
- </table>
- </body>
- </html>
+  <head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+  </head>
+  <body>
+    <div class="container">
+      <div class="page-header">
+        <h1>GoTel Reservations</h1>
+      </div>
+      <div class="row">
+        <div class="col-lg-12 col-md-12 col-sm-12">
+          <table class="table table-bordered table-condensed">
+            <thead>
+          <tr>
+                <th>JobID</th>
+                <th>App</th>
+                <th>Component</th>
+                <th>Owner</th>
+                <th>Frequency</th>
+                <th>Time Units</th>
+                <th>Last Checkin</th>
+                <th>Time Since Last Checkin</th>
+                <th>Num Checkins</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+            {{range .}}
+              <tr>
+                <td>{{.JobID}}</td>
+                <td>{{.App}}</td>
+                <td>{{.Component}}</td>
+                <td>{{.Owner}}</td>
+                <td>{{.Frequency}}</td>
+                <td>{{.TimeUnits}}</td>
+                <td>{{.LastCheckinStr}}</td>
+                <td>{{.TimeSinceLastCheckin}}</td>
+                <td>{{.NumCheckins}}</td>
+              {{ if .FailingSLA }}
+                <td class="danger">FAILING</td>
+              {{ else }}
+                <td class="success">OK</td>
+              {{ end }}
+              </tr>
+            {{end}}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/store.go
+++ b/store.go
@@ -14,17 +14,18 @@ type Endpoint struct {
 
 // reservation is when an app first registers that it will be checking into our gotel
 type reservation struct {
-	JobID          int    `json:"job_id"`
-	Owner          string `json:"owner"`
-	Notify         string `json:"notify"`
-	App            string `json:"app"`
-	Component      string `json:"component"`
-	Frequency      int    `json:"frequency"`
-	TimeUnits      string `json:"time_units"`
-	LastCheckin    int64  `json:"last_checkin"`
-	LastCheckinStr string `json:"last_checkin_str"` // human readable time
-	FailingSLA     bool   `json:"failing_sla"`
-	NumCheckins    int    `json:"number_of_checkins"`
+	JobID                int    `json:"job_id"`
+	Owner                string `json:"owner"`
+	Notify               string `json:"notify"`
+	App                  string `json:"app"`
+	Component            string `json:"component"`
+	Frequency            int    `json:"frequency"`
+	TimeUnits            string `json:"time_units"`
+	LastCheckin          int64  `json:"last_checkin"`
+	LastCheckinStr       string `json:"last_checkin_str"` // human readable time
+	TimeSinceLastCheckin string `json:"time_sine_last_checkin"`
+	FailingSLA           bool   `json:"failing_sla"`
+	NumCheckins          int    `json:"number_of_checkins"`
 }
 
 // checkin holds a struct that is populated when an app checks in as still alive

--- a/utils.go
+++ b/utils.go
@@ -2,8 +2,46 @@ package gotel
 
 import (
 	"errors"
+	"fmt"
+	"math"
 	"net"
+	"sort"
+	"time"
 )
+
+const (
+	Minute   = 60
+	Hour     = 60 * Minute
+	Day      = 24 * Hour
+	Week     = 7 * Day
+	Month    = 30 * Day
+	Year     = 12 * Month
+	LongTime = 37 * Year
+)
+
+var magnitudes = []struct {
+	d      int64
+	format string
+	divby  int64
+}{
+	{1, "now", 1},
+	{2, "1 second %s", 1},
+	{Minute, "%d seconds %s", 1},
+	{2 * Minute, "1 minute %s", 1},
+	{Hour, "%d minutes %s", Minute},
+	{2 * Hour, "1 hour %s", 1},
+	{Day, "%d hours %s", Hour},
+	{2 * Day, "1 day %s", 1},
+	{Week, "%d days %s", Day},
+	{2 * Week, "1 week %s", 1},
+	{Month, "%d weeks %s", Week},
+	{2 * Month, "1 month %s", 1},
+	{Year, "%d months %s", Month},
+	{18 * Month, "1 year %s", 1},
+	{2 * Year, "2 years %s", 1},
+	{LongTime, "%d years %s", Year},
+	{math.MaxInt64, "a long while %s", 1},
+}
 
 // returns the external IP of the machine you're on
 func externalIP() (string, error) {
@@ -41,4 +79,38 @@ func externalIP() (string, error) {
 		}
 	}
 	return "", errors.New("are you connected to the network?")
+}
+
+func RelTime(a, b time.Time, albl, blbl string) string {
+	lbl := albl
+	diff := b.Unix() - a.Unix()
+
+	after := a.After(b)
+	if after {
+		lbl = blbl
+		diff = a.Unix() - b.Unix()
+	}
+
+	n := sort.Search(len(magnitudes), func(i int) bool {
+		return magnitudes[i].d > diff
+	})
+
+	mag := magnitudes[n]
+	args := []interface{}{}
+	escaped := false
+	for _, ch := range mag.format {
+		if escaped {
+			switch ch {
+			case '%':
+			case 's':
+				args = append(args, lbl)
+			case 'd':
+				args = append(args, diff/mag.divby)
+			}
+			escaped = false
+		} else {
+			escaped = ch == '%'
+		}
+	}
+	return fmt.Sprintf(mag.format, args...)
 }


### PR DESCRIPTION
Since we are using bootstrap already, let's utilize bootstrap for the markup.

Add a new colunm to the displayable status table, and json responses
with a human readable time of how long ago the job checked-in

Don't use a hard-coded port in InitAPI since it is being passed in.
Used the passed in port instead.