### PR TITLE
Fix missing field in api requests

### DIFF
--- a/alerter_pagerduty.go
+++ b/alerter_pagerduty.go
@@ -14,12 +14,12 @@ func init() {
 }
 
 type pagerDutyAlerter struct {
-	Cfg config
+	Cfg Config
 }
 
 func (s *pagerDutyAlerter) Bootstrap() {
 	if pdServiceKey != "" {
-		s.Cfg.Pagerduty.Servicekey = pdServiceKey
+		s.Cfg.PagerDuty.ServiceKey = pdServiceKey
 	}
 }
 
@@ -29,16 +29,16 @@ func (s *pagerDutyAlerter) Name() string {
 
 func (s *pagerDutyAlerter) Alert(res reservation) bool {
 
-	l.info("PagerDuty API key [%s]", s.Cfg.Pagerduty.Servicekey)
+	l.info("PagerDuty API key [%s]", s.Cfg.PagerDuty.ServiceKey)
 
-	pager.ServiceKey = s.Cfg.Pagerduty.Servicekey
+	pager.ServiceKey = s.Cfg.PagerDuty.ServiceKey
 	incidentKey, err := pager.Trigger(res.AlertMessage)
 
 	if err != nil {
-		l.err("[ERROR] Unable to create pagerduty alert for job [%s] component [%s] error [%v]\n", res.App, res.Component, err)
+		l.err("[ERROR] Unable to create PagerDuty alert for job [%s] component [%s] error [%v]\n", res.App,
+			res.Component, err)
 		return false
-	} else {
-		l.info("PagerDuty incident key created %s\n", incidentKey)
-		return true
 	}
+	l.info("PagerDuty incident key created %s\n", incidentKey)
+	return true
 }

--- a/alerter_smtp.go
+++ b/alerter_smtp.go
@@ -31,7 +31,7 @@ func (s *smtpAlerter) Bootstrap() {
 }
 
 type smtpAlerter struct {
-	Cfg config
+	Cfg Config
 }
 
 func (s *smtpAlerter) Name() string {
@@ -57,11 +57,12 @@ func (s *smtpAlerter) Alert(res reservation) bool {
 		now := time.Now().Format(time.RFC822) // in case email delivery delay, let them know the actual date
 		subject := "Job Failed to checkin"
 		body := fmt.Sprintf("%s\n\nAlert time is [%s]\n\nNotification list [%s]", res.AlertMessage, now, res.Notify)
-		message := bytes.NewBufferString(fmt.Sprintf("Subject: %s\r\nFrom: %s\r\nReply-to: %s\r\nTo: %s\r\n\r\n%s", subject, s.Cfg.Smtp.Fromaddress, s.Cfg.Smtp.ReplyTO, emailAddy, body))
+		message := bytes.NewBufferString(fmt.Sprintf("Subject: %s\r\nFrom: %s\r\nReply-to: %s\r\nTo: %s\r\n\r\n%s",
+			subject, s.Cfg.SMTP.FromAddress, s.Cfg.SMTP.ReplyTO, emailAddy, body))
 
 		// Now push out the complete mail message
 		auth := smtp.PlainAuth("", smtpUser, smtpPass, smtpHost)
-		if err = smtp.SendMail(smtpPair, auth, s.Cfg.Smtp.Fromaddress, []string{emailAddy}, message.Bytes()); err != nil {
+		if err = smtp.SendMail(smtpPair, auth, s.Cfg.SMTP.FromAddress, []string{emailAddy}, message.Bytes()); err != nil {
 			l.warn("[WARN] Unable to write to mail server: host: [%s] user: [%s] err: [%v]\n", smtpHost, smtpUser, err)
 			return false
 		}

--- a/api.go
+++ b/api.go
@@ -22,9 +22,9 @@ type badGuest struct {
 }
 
 type node struct {
-	Id            int
-	IpAddress     string
-	NodeId        int
+	ID            int
+	IPAddress     string
+	NodeID        int
 	IsCoordinator bool
 }
 
@@ -34,20 +34,28 @@ func writeError(w http.ResponseWriter, e interface{}) {
 	w.WriteHeader(http.StatusBadRequest)
 	w.Header().Set("Content-Type", "application/json")
 	if bytes, err := json.Marshal(e); err != nil {
-		w.Write([]byte("Could not encode error"))
-		return
+		_, err = w.Write([]byte("Could not encode error"))
+		if err != nil {
+			l.err("Could not encode error [%v]", err)
+		}
 	} else {
-		w.Write(bytes)
-		return
+		_, err = w.Write(bytes)
+		if err != nil {
+			l.err("Could not write error [%v]", err)
+		}
 	}
 }
 
 func writeResponse(w http.ResponseWriter, e interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	if bytes, err := json.Marshal(e); err != nil {
-		w.Write([]byte("Could not encode response"))
+		l.err("Could not encode response [%v]", err)
+		writeError(w, "Could not encode response")
 	} else {
-		w.Write(bytes)
+		_, err = w.Write(bytes)
+		if err != nil {
+			l.err("Could not write response [%v]", err)
+		}
 		return
 	}
 }
@@ -62,12 +70,12 @@ func (ge *Endpoint) makeReservation(w http.ResponseWriter, req *http.Request) {
 
 	err = validateReservation(res)
 	if err != nil {
-		l.warn("Invalid reservations [%q]", res)
+		l.warn("Invalid reservations [%v]", res)
 		writeError(w, fmt.Sprintf("Unable to store reservation, validation failure [%v]", err))
 		return
 	}
 
-	l.info("%q", res)
+	l.info("%v", res)
 
 	_, err = storeReservation(ge.Db, res)
 	if err != nil {
@@ -89,8 +97,11 @@ func (ge *Endpoint) getReservations() ([]reservation, error) {
 	for rows.Next() {
 		var alertMessage sql.NullString
 		res := reservation{}
-		rows.Scan(&res.JobID, &res.App, &res.Component, &res.Owner, &res.Notify, &alertMessage, &res.Frequency,
+		err = rows.Scan(&res.JobID, &res.App, &res.Component, &res.Owner, &res.Notify, &alertMessage, &res.Frequency,
 			&res.TimeUnits, &res.LastCheckin, &res.NumCheckins)
+		if err != nil {
+			return nil, err
+		}
 		lastCheckin := time.Unix(res.LastCheckin, 0)
 		res.TimeSinceLastCheckin = RelTime(lastCheckin, time.Now(), "ago", "")
 		res.LastCheckinStr = lastCheckin.Format(time.RFC1123)
@@ -118,17 +129,20 @@ func (ge *Endpoint) getNodes() ([]node, error) {
 	defer rows.Close()
 	for rows.Next() {
 		res := node{IsCoordinator: false}
-		rows.Scan(&res.Id, &res.IpAddress, &res.NodeId)
-
-		resp, err := http.Get(fmt.Sprintf("http://%s:8080/is-coordinator", res.IpAddress))
+		err = rows.Scan(&res.ID, &res.IPAddress, &res.NodeID)
 		if err != nil {
-			l.warn("Unable to contact node [%s] assuming offline", res.IpAddress)
+			return nil, err
+		}
+
+		resp, err := http.Get(fmt.Sprintf("http://%s:8080/is-coordinator", res.IPAddress))
+		if err != nil {
+			l.warn("Unable to contact node [%s] assuming offline", res.IPAddress)
 			continue
 		}
 		defer resp.Body.Close()
 
 		if resp.StatusCode != 200 {
-			l.warn("Didn't get a 200OK reply back from ip [%s]", res.IpAddress)
+			l.warn("Didn't get a 200OK reply back from ip [%s]", res.IPAddress)
 			continue
 		}
 
@@ -155,7 +169,10 @@ func (ge *Endpoint) getBadGuests() ([]badGuest, error) {
 	defer rows.Close()
 	for rows.Next() {
 		res := badGuest{}
-		rows.Scan(&res.App, &res.Component, &res.NumFails)
+		err = rows.Scan(&res.App, &res.Component, &res.NumFails)
+		if err != nil {
+			return nil, err
+		}
 		guests = append(guests, res)
 	}
 	return guests, nil
@@ -307,7 +324,10 @@ func (ge *Endpoint) InitAPI(port int, htmlPath string) {
 				if err != nil {
 					l.err(err.Error())
 				} else {
-					t.Execute(w, &reservations)
+					err = t.Execute(w, &reservations)
+					if err != nil {
+						l.err(err.Error())
+					}
 				}
 
 			}
@@ -328,7 +348,10 @@ func (ge *Endpoint) InitAPI(port int, htmlPath string) {
 				if err != nil {
 					l.err(err.Error())
 				} else {
-					t.Execute(w, &reservations)
+					err = t.Execute(w, &reservations)
+					if err != nil {
+						l.err(err.Error())
+					}
 				}
 			}
 		}
@@ -347,7 +370,10 @@ func (ge *Endpoint) InitAPI(port int, htmlPath string) {
 				if err != nil {
 					l.err(err.Error())
 				} else {
-					t.Execute(w, &reservations)
+					err = t.Execute(w, &reservations)
+					if err != nil {
+						l.err(err.Error())
+					}
 				}
 			}
 		}

--- a/config.go
+++ b/config.go
@@ -6,27 +6,28 @@ import (
 
 var l *logging
 
-type config struct {
+// Config is the service configuration
+type Config struct {
 	Main struct {
 		GotelOwnerEmail    string
 		HoursBetweenAlerts int64
 		DaysToStoreLogs    int
 	}
-	Smtp struct {
+	SMTP struct {
 		Enabled     bool
-		Fromaddress string
+		FromAddress string
 		ReplyTO     string
 	}
-	Pagerduty struct {
+	PagerDuty struct {
 		Enabled    bool
-		Servicekey string
+		ServiceKey string
 	}
 }
 
 // NewConfig returns a gotel config with configPath and sysLogEnabled set.
 // As part of initialization it will also parse the provided config file.
-func NewConfig(confPath string, sysLogEnabled bool) config {
-	conf := config{}
+func NewConfig(confPath string, sysLogEnabled bool) Config {
+	conf := Config{}
 	l = &logging{EnableSYSLOG: sysLogEnabled}
 	l.setLogOutput()
 

--- a/public/nodes.html
+++ b/public/nodes.html
@@ -17,16 +17,16 @@
           <table class="table table-bordered table-condensed">
             <thead>
             <tr>
-                  <th>NodeID</th>
-                  <th>IpAddress</th>
+                  <th>Node ID</th>
+                  <th>IP Address</th>
                   <th>Coordinator Node</th>
             </tr>
               </thead>
               <tbody>
             {{range .}}
               <tr>
-                <td>{{.NodeId}}</td>
-                <td>{{.IpAddress}}</td>
+                <td>{{.NodeID}}</td>
+                <td>{{.IPAddress}}</td>
                 {{ if .IsCoordinator }}
                 <td class="success">YES</td>
                 {{ else }}

--- a/store.go
+++ b/store.go
@@ -58,7 +58,7 @@ func InitDb(host, user, pass string, conf config) *sql.DB {
 	}
 	err = db.Ping()
 	if err != nil {
-		panic(fmt.Sprintf("Unable to ping the DB at host [%s] user [%s]", host, user))
+		panic(fmt.Sprintf("Unable to ping the DB at host [%s] user [%s]: %v", host, user, err))
 	}
 	bootstrapDb(db, conf)
 	return db

--- a/store.go
+++ b/store.go
@@ -24,7 +24,7 @@ type reservation struct {
 	TimeUnits            string `json:"time_units"`
 	LastCheckin          int64  `json:"last_checkin"`
 	LastCheckinStr       string `json:"last_checkin_str"` // human readable time
-	TimeSinceLastCheckin string `json:"time_sine_last_checkin"`
+	TimeSinceLastCheckin string `json:"time_since_last_checkin"`
 	FailingSLA           bool   `json:"failing_sla"`
 	NumCheckins          int    `json:"number_of_checkins"`
 }

--- a/utils.go
+++ b/utils.go
@@ -12,12 +12,19 @@ import (
 )
 
 const (
+	// Minute is the nubmer of seconds in a minute
 	Minute   = 60
+	// Hour is the nubmer of seconds in an hour
 	Hour     = 60 * Minute
+	// Day is the nubmer of seconds in a day
 	Day      = 24 * Hour
+	// Week is the nubmer of seconds in a week
 	Week     = 7 * Day
+	// Month is the nubmer of seconds in a 30 day month
 	Month    = 30 * Day
+	// Year is the nubmer of seconds in almost a year
 	Year     = 12 * Month
+	// LongTime is the nubmer of seconds in a while
 	LongTime = 37 * Year
 )
 
@@ -83,6 +90,7 @@ func externalIP() (string, error) {
 	return "", errors.New("are you connected to the network?")
 }
 
+// RelTime returns the duration between to times, formatted as a string
 func RelTime(a, b time.Time, albl, blbl string) string {
 	lbl := albl
 	diff := b.Unix() - a.Unix()


### PR DESCRIPTION
A recent schema change was causing API requests to show meaningless data because of a missing field when scanning query results. 8a81917 resolves this issue.

21909eb adds extra error checks, that may have caught this, and resolves some linting messages.